### PR TITLE
33062 Adds a call to log a user metric for the DCC version

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -55,7 +55,10 @@ class MariEngine(sgtk.platform.Engine):
                 mari.utils.message(msg, "Shotgun")
                 os.environ["SGTK_MARI_VERSION_WARNING_SHOWN"] = "1"         
             
-            self.log_warning(msg)            
+            self.log_warning(msg)
+
+        self.log_user_attribute_metric("Mari version",
+            "%s.%s.%s" % (mari_version.major(), mari_version.minor(), mari_version.revision()))
     
         # cache handles to the various manager instances:
         tk_mari = self.import_module("tk_mari")

--- a/engine.py
+++ b/engine.py
@@ -57,8 +57,16 @@ class MariEngine(sgtk.platform.Engine):
             
             self.log_warning(msg)
 
-        self.log_user_attribute_metric("Mari version",
-            "%s.%s.%s" % (mari_version.major(), mari_version.minor(), mari_version.revision()))
+        try:
+            self.log_user_attribute_metric("Mari version",
+                "%s.%s.%s" % (mari_version.major(),
+                              mari_version.minor(),
+                              mari_version.revision()
+                )
+            )
+        except:
+            # ignore all errors. ex: using a core that doesn't support metrics
+            pass
     
         # cache handles to the various manager instances:
         tk_mari = self.import_module("tk_mari")

--- a/info.yml
+++ b/info.yml
@@ -36,5 +36,3 @@ description: "Shotgun Integration in Mari"
 requires_shotgun_version:
 requires_core_version: "v0.14.66"
 
-# XXX will require core version with metrics logging
-

--- a/info.yml
+++ b/info.yml
@@ -36,4 +36,5 @@ description: "Shotgun Integration in Mari"
 requires_shotgun_version:
 requires_core_version: "v0.14.66"
 
+# XXX will require core version with metrics logging
 


### PR DESCRIPTION
The call logs the metric internally and ignores any errors. This prevents the need to force the engine's users to update to a new core that supports metrics. When a supported core is updated, the metric will be logged.