### PR TITLE
For #44051 Update metrics-related logging

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -26,16 +26,11 @@ class MariEngine(sgtk.platform.Engine):
     @property
     def host_info(self):
         """
-        :returns: A {"name": application name, "version": application version, "stage": application build info}
+        :returns: A {"name": application name, "version": application version}
                   dictionary with informations about the application hosting this
                   engine.
-
-        NOTE:
-
-        From installed documentation (Mac)
-        file:///Applications/Mari3.3v1/Mari3.3v1.app/Contents/pydoc/mari.AppVersion-class.html
         """
-        host_info = {"name": "Mari", "version": "unknown", "stage": "unknown"}
+        host_info = {"name": "Mari", "version": "unknown"}
 
         try:
             mari_version = mari.app.version()
@@ -45,10 +40,6 @@ class MariEngine(sgtk.platform.Engine):
                 mari_version.minor(),
                 mari_version.revision()
             )
-
-            # The 'stage' method returns a string such as
-            # 'mari.Mari.AppVersion.Stage.RELEASE'
-            host_info["stage"] = mari_version.stage()
 
         except:
             # Fallback to initialization value above

--- a/engine.py
+++ b/engine.py
@@ -26,9 +26,22 @@ class MariEngine(sgtk.platform.Engine):
     @property
     def host_info(self):
         """
-        :returns: A {"name": application name, "version": application version}
-                  dictionary with informations about the application hosting this
-                  engine.
+        :returns: A dictionary with information about the application hosting this engine.
+
+        The returned dictionary is of the following form on success:
+
+            {
+                "name": "Mari",
+                "version": "1.2.3",
+            }
+
+        The returned dictionary is of following form on an error occurs preventing
+        the version identification.
+
+            {
+                "name": "Mari",
+                "version: "unknown"
+            }
         """
         host_info = {"name": "Mari", "version": "unknown"}
 

--- a/engine.py
+++ b/engine.py
@@ -35,7 +35,7 @@ class MariEngine(sgtk.platform.Engine):
                 "version": "1.2.3",
             }
 
-        The returned dictionary is of following form on an error occurs preventing
+        The returned dictionary is of following form on an error preventing
         the version identification.
 
             {

--- a/engine.py
+++ b/engine.py
@@ -22,6 +22,40 @@ class MariEngine(sgtk.platform.Engine):
     """
     The engine class
     """
+
+    @property
+    def host_info(self):
+        """
+        :returns: A {"name": application name, "version": application version, "stage": application build info}
+                  dictionary with informations about the application hosting this
+                  engine.
+
+        NOTE:
+
+        From installed documentation (Mac)
+        file:///Applications/Mari3.3v1/Mari3.3v1.app/Contents/pydoc/mari.AppVersion-class.html
+        """
+        host_info = {"name": "Mari", "version": "unknown", "stage": "unknown"}
+
+        try:
+            mari_version = mari.app.version()
+
+            host_info["version"] = "%s.%s.%s" % (
+                mari_version.major(),
+                mari_version.minor(),
+                mari_version.revision()
+            )
+
+            # The 'stage' method returns a string such as
+            # 'mari.Mari.AppVersion.Stage.RELEASE'
+            host_info["stage"] = mari_version.stage()
+
+        except:
+            # Fallback to initialization value above
+            pass
+
+        return host_info
+
     def pre_app_init(self):
         """
         Engine construction/setup done before any apps are initialized
@@ -56,17 +90,6 @@ class MariEngine(sgtk.platform.Engine):
                 os.environ["SGTK_MARI_VERSION_WARNING_SHOWN"] = "1"         
             
             self.log_warning(msg)
-
-        try:
-            self.log_user_attribute_metric("Mari version",
-                "%s.%s.%s" % (mari_version.major(),
-                              mari_version.minor(),
-                              mari_version.revision()
-                )
-            )
-        except:
-            # ignore all errors. ex: using a core that doesn't support metrics
-            pass
     
         # cache handles to the various manager instances:
         tk_mari = self.import_module("tk_mari")


### PR DESCRIPTION
Here is the metrics logged on Amplitude:

```
 "event_properties": { "Engine": "tk-mari", "Engine Version": "v1.1.4", "Host App": "Mari", "Host App Version": "3.3.1", "event_group": "Toolkit", "event_name": "Launched Engine", "event_type": "event", "from_api": true }
```

