### PR TITLE
SG-15691: Preliminary support for Python 3

### DIFF
--- a/python/tk_mari/menu_generation.py
+++ b/python/tk_mari/menu_generation.py
@@ -203,14 +203,13 @@ class MenuGenerator(object):
         for disk_location in paths:
 
             # get the setting
-            system = sys.platform
 
             # run the app
-            if system == "linux2":
+            if sgtk.util.is_linux():
                 cmd = 'xdg-open "%s"' % disk_location
-            elif system == "darwin":
+            elif sgtk.util.is_macos():
                 cmd = 'open "%s"' % disk_location
-            elif system == "win32":
+            elif sgtk.util.is_windows():
                 cmd = 'cmd.exe /C start "Folder" "%s"' % disk_location
             else:
                 raise Exception("Platform '%s' is not supported." % system)

--- a/python/tk_mari/metadata.py
+++ b/python/tk_mari/metadata.py
@@ -285,7 +285,7 @@ class MetadataManager(object):
         :param metadata:    The metadata to add
         :param md_details:  Definitions of the metadata to add.
         """
-        for name, details in md_details.iteritems():
+        for name, details in md_details.items():
             value = metadata.get(name, details.get("default_value"))
             if value == None:
                 continue
@@ -312,7 +312,7 @@ class MetadataManager(object):
         :returns:           A dictionary containing the metadata retrieved from the object
         """
         metadata = {}
-        for name, _ in md_details.iteritems():
+        for name, _ in md_details.items():
             md_name = "tk_%s" % name
             if obj.hasMetadata(md_name):
                 metadata[name] = obj.metadata(md_name)

--- a/python/tk_mari/utils.py
+++ b/python/tk_mari/utils.py
@@ -70,7 +70,7 @@ def update_publish_records(sg_publishes, min_fields=None):
     if to_update:
         try:
             # query shotgun for the record of any publishes that need updating:
-            filters = [["id", "in", to_update.keys()]]
+            filters = [["id", "in", list(to_update.keys())]]
             sg_res = engine.shotgun.find(
                 sg_publishes[0]["type"], filters, required_fields
             )

--- a/startup/init.py
+++ b/startup/init.py
@@ -13,6 +13,12 @@ from __future__ import print_function
 import os
 import mari
 
+# HACK: Do not merge. It appears the Python 3 version of Mari does not properly added PYTHONPATH to sys.path
+import sys
+import os
+
+sys.path.insert(0, os.environ["PYTHONPATH"])
+
 
 def show_warning(msg):
     """

--- a/startup/init.py
+++ b/startup/init.py
@@ -13,11 +13,6 @@ from __future__ import print_function
 import os
 import mari
 
-# HACK: Do not merge. It appears the Python 3 version of Mari does not properly added PYTHONPATH to sys.path
-import sys
-
-sys.path.insert(0, os.environ["PYTHONPATH"])
-
 
 def show_warning(msg):
     """

--- a/startup/init.py
+++ b/startup/init.py
@@ -15,7 +15,6 @@ import mari
 
 # HACK: Do not merge. It appears the Python 3 version of Mari does not properly added PYTHONPATH to sys.path
 import sys
-import os
 
 sys.path.insert(0, os.environ["PYTHONPATH"])
 


### PR DESCRIPTION
This introduces support for Python 3 in Mari. There's isn't much to be said, since it's the same thing as other engines. One thing to note however is that the Mari Tech Preview is broken at the moment. It seems the `PYTHONPATH` environment variable is not being used to initialize `sys.path` when the interpreter is started. This causes a problem because our launch logic puts Toolkit in `PYTHONPATH`, but when our scripts run inside Mari we can't import Toolkit. I've made a dirty-hack right now to add Toolkit to the `PYTHONPATH`, but I don't think we should merge it and claim Python 3 support.