### PR TITLE
SG-28194: Updated support from Mari4 to Mari6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ exclude: "ui\/.*py$"
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.4.0
     hooks:
     # Ensures the code is syntaxically correct
     - id: check-ast
@@ -32,7 +32,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 19.10b0
+    rev: 23.1.0
     hooks:
     - id: black
       language_version: python3

--- a/engine.py
+++ b/engine.py
@@ -69,8 +69,8 @@ class MariEngine(sgtk.platform.Engine):
         self.log_debug("%s: Initializing..." % self)
 
         # check that this version of Mari is supported:
-        MIN_VERSION = (2, 6, 1)  # completely unsupported below this!
-        MAX_VERSION = (4, 7)  # untested above this so display a warning
+        MIN_VERSION = (4, 0, 0)  # completely unsupported below this!
+        MAX_VERSION = (6, 0)  # untested above this so display a warning
 
         mari_version = mari.app.version()
         if mari_version.major() < MIN_VERSION[0] or (

--- a/hooks/tk-multi-publish2/basic/collector.py
+++ b/hooks/tk-multi-publish2/basic/collector.py
@@ -118,7 +118,6 @@ class MariSessionCollector(HookBaseClass):
                 # add item for each collected layer:
                 found_layer_names = set()
                 for layer in collected_layers:
-
                     # for now, duplicate layer names aren't allowed!
                     layer_name = layer.name()
                     if layer_name in found_layer_names:

--- a/python/tk_mari/menu_generation.py
+++ b/python/tk_mari/menu_generation.py
@@ -118,7 +118,7 @@ class MenuGenerator(object):
 
         # now enumerate all items and create menu objects for them
         menu_items = []
-        for (cmd_name, cmd_details) in self._engine.commands.items():
+        for cmd_name, cmd_details in self._engine.commands.items():
             # if not (cmd_name == "SG File Manager..." or cmd_name == "Version up Current Scene..."):
             menu_items.append(AppCommand(cmd_name, cmd_details, self.__action_factory))
 
@@ -201,7 +201,6 @@ class MenuGenerator(object):
         # launch one window for each location on disk
         paths = self._engine.context.filesystem_locations
         for disk_location in paths:
-
             # get the setting
 
             # run the app
@@ -317,7 +316,7 @@ class AppCommand(object):
         app_instance = self.properties["app"]
         engine = app_instance.engine
 
-        for (app_instance_name, app_instance_obj) in engine.apps.items():
+        for app_instance_name, app_instance_obj in engine.apps.items():
             if app_instance_obj == app_instance:
                 # found our app!
                 return app_instance_name


### PR DESCRIPTION
Updated `engine.py` file to don't raise a warning dialog when using newer Mari versions (v5.0 and v6.0).

Dropped support for older Mari versions than v4.0.