### PR TITLE
SG-38377 Update Mari supported versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,16 +8,19 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+default_language_version:
+    python: python3
+
 # Exclude the UI files, as they are auto-generated.
 exclude: "ui\/.*py$"
+
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
     # Ensures the code is syntaxically correct
     - id: check-ast
-      language_version: python3
     # Ensures a file name will resolve on all platform
     - id: check-case-conflict
     # Checks files with the execute bit set have shebangs
@@ -31,8 +34,7 @@ repos:
     # Removes trailing whitespaces.
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
-  - repo: https://github.com/ambv/black
-    rev: 23.1.0
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
     hooks:
     - id: black
-      language_version: python3

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Toolkit Engine for Mari
 
-![Supported Mari versions: 6 - 7](https://img.shields.io/badge/Mari-7_|_6-blue.svg "Supported Mari versions")
-[![Supported VFX Platform: 2022 - 2025](https://img.shields.io/badge/VFX_Platform-2025_|_2024_|_2023_|_2022-blue.svg)](http://www.vfxplatform.com/ "Supported VFX Platform")
-[![Supported Python versions: 3.9 - 3.11](https://img.shields.io/badge/Python-3.11_|_3.10_|_3.9-blue.svg?logo=python)](https://www.python.org/ "Supported Python versions")
+![Supported Mari versions: 6 - 7](https://img.shields.io/badge/Mari-7_|_6-blue "Supported Mari versions")
+[![Supported VFX Platform: 2022 - 2025](https://img.shields.io/badge/VFX_Platform-2025_|_2024_|_2023_|_2022-blue)](http://www.vfxplatform.com/ "Supported VFX Platform")
+[![Supported Python versions: 3.9 - 3.11](https://img.shields.io/badge/Python-3.11_|_3.10_|_3.9-blue?logo=python&logoColor=f5f5f5)](https://www.python.org/ "Supported Python versions")
 
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Engines/tk-mari?repoName=shotgunsoftware%2Ftk-mari&branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=97&repoName=shotgunsoftware%2Ftk-mari&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
-[![VFX Platform](https://img.shields.io/badge/vfxplatform-2025%20%7C%202024%20%7C%202023%20%7C%202022-blue.svg)](http://www.vfxplatform.com/)
-[![Python](https://img.shields.io/badge/python-3.11%20%7C%203.10%20%7C%203.9-blue.svg)](https://www.python.org/)
+# Toolkit Engine for Mari
+
+![Supported Mari versions: 6 - 7](https://img.shields.io/badge/Mari-7_|_6-blue.svg "Supported Mari versions")
+[![Supported VFX Platform: 2022 - 2025](https://img.shields.io/badge/VFX_Platform-2025_|_2024_|_2023_|_2022-blue.svg)](http://www.vfxplatform.com/ "Supported VFX Platform")
+[![Supported Python versions: 3.9 - 3.11](https://img.shields.io/badge/Python-3.11_|_3.10_|_3.9-blue.svg?logo=python)](https://www.python.org/ "Supported Python versions")
+
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Engines/tk-mari?repoName=shotgunsoftware%2Ftk-mari&branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=97&repoName=shotgunsoftware%2Ftk-mari&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Linting](https://img.shields.io/badge/PEP8%20by-Hound%20CI-a873d1.svg)](https://houndci.com)

--- a/engine.py
+++ b/engine.py
@@ -68,8 +68,8 @@ class MariEngine(sgtk.platform.Engine):
         self.log_debug("%s: Initializing..." % self)
 
         # check that this version of Mari is supported:
-        MIN_VERSION = (4, 0, 0)  # completely unsupported below this!
-        MAX_VERSION = (7, 0)  # untested above this so display a warning
+        MIN_VERSION = (5, 0, 0)  # completely unsupported below this!
+        MAX_VERSION = (7, 1)  # untested above this so display a warning
 
         mari_version = mari.app.version()
         if mari_version.major() < MIN_VERSION[0] or (

--- a/info.yml
+++ b/info.yml
@@ -23,7 +23,7 @@ configuration:
                         it isn't yet fully supported and tested with Toolkit.  To disable the warning
                         dialog for the version you are testing, it is recomended that you set this
                         value to the current major version + 1."
-        default_value:  2
+        default_value:  7
 
 # the Shotgun fields that this engine needs in order to operate correctly
 requires_shotgun_fields:


### PR DESCRIPTION
Add support for Mari 7.1

- Update newest supported version from `7.0` to `7.1`
- Update oldest compatible version from `4.0` to `5.0`. Older versions are shipping Python 2.
- Update pre-commit configuration file
- Update badges